### PR TITLE
feat: add simple retry policy with subclass of HTTPXRequest and change AsyncHTTPTransport init call (5 retries by default) #24

### DIFF
--- a/krddevbot/__main__.py
+++ b/krddevbot/__main__.py
@@ -17,6 +17,7 @@ from krddevbot.antispam import antispam_reactions_checking, greet_chat_members
 from krddevbot.logging import init_logging
 from krddevbot.message_formatter import md
 from krddevbot.tander import days_without_mention
+from krddevbot.request.httpx_request_with_retry import HTTPXRequestWithRetry
 
 
 async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -29,7 +30,17 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 
 if __name__ == "__main__":
     init_logging()
-    application = Application.builder().token(settings.BOT_TOKEN).build()
+
+    application = Application.builder().token(settings.BOT_TOKEN)
+
+    # By default, PTB will use the httpx library for the networking backend, i.e. making requests to the Bot API.
+    # However, you are free to use a custom backend implementation as well. For this, you'll have to implement
+    # the BaseRequest interface class and pass two instances of your custom networking class to
+    # ApplicationBuilder.request and ApplicationBuilder.get_updates_request.
+    # https://github.com/python-telegram-bot/python-telegram-bot/wiki/Architecture
+    application = application.request(HTTPXRequestWithRetry()).get_updates_request(HTTPXRequestWithRetry())
+
+    application = application.build()
 
     application.add_handler(CommandHandler("ping", help_command))
     application.add_handler(ChatMemberHandler(greet_chat_members, ChatMemberHandler.CHAT_MEMBER))

--- a/krddevbot/request/httpx_request_with_retry.py
+++ b/krddevbot/request/httpx_request_with_retry.py
@@ -1,0 +1,57 @@
+import httpx
+
+from typing import Collection, Optional, Union
+
+from telegram._utils.types import HTTPVersion, SocketOpt
+from telegram.request._httpxrequest import HTTPXRequest
+
+RETRY_TIMES_DEFAULTS = 5
+
+
+class HTTPXRequestWithRetry(HTTPXRequest):
+    def __init__(
+        self,
+        connection_pool_size: int = 1,
+        read_timeout: Optional[float] = 5.0,
+        write_timeout: Optional[float] = 5.0,
+        connect_timeout: Optional[float] = 5.0,
+        pool_timeout: Optional[float] = 1.0,
+        http_version: HTTPVersion = "1.1",
+        socket_options: Optional[Collection[SocketOpt]] = None,
+        proxy: Optional[Union[str, httpx.Proxy, httpx.URL]] = None,
+        retries: int = RETRY_TIMES_DEFAULTS,
+    ):
+        self._http_version = http_version
+        timeout = httpx.Timeout(
+            connect=connect_timeout,
+            read=read_timeout,
+            write=write_timeout,
+            pool=pool_timeout,
+        )
+        limits = httpx.Limits(
+            max_connections=connection_pool_size,
+            max_keepalive_connections=connection_pool_size,
+        )
+
+        if http_version not in ("1.1", "2", "2.0"):
+            raise ValueError("`http_version` must be either '1.1', '2.0' or '2'.")
+
+        http1 = http_version == "1.1"
+        http_kwargs = {"http1": http1, "http2": not http1}
+        transport = (
+            httpx.AsyncHTTPTransport(
+                socket_options=socket_options,
+                retries=retries,
+            )
+            if socket_options or retries
+            else None
+        )
+        self._client_kwargs = {
+            "timeout": timeout,
+            "proxies": proxy,
+            "limits": limits,
+            "transport": transport,
+            **http_kwargs,
+        }
+
+        self._client = self._build_client()


### PR DESCRIPTION
Добавлен класс HTTPXRequestWithRetry унаследованный от HTTPXRequest, переопределен init для проброса retries в httpx.AsyncHTTPTransport.

Пробовал отключать сеть и смотреть логи, отрабатывает нормально:

```python
telegram.error.NetworkError: httpx.ConnectError: [Errno -3] Temporary failure in name resolution
2024-06-09 14:51:22,558 - httpcore.connection - DEBUG - connect_tcp.started host='api.telegram.org' port=443 local_address=None timeout=5.0 socket_options=None
2024-06-09 14:51:22,561 - httpcore.connection - DEBUG - connect_tcp.failed exception=ConnectError(gaierror(-3, 'Temporary failure in name resolution'))
2024-06-09 14:51:22,561 - httpcore.connection - DEBUG - retry.started host='api.telegram.org' port=443 local_address=None timeout=5.0 socket_options=None
2024-06-09 14:51:22,561 - httpcore.connection - DEBUG - retry.complete
2024-06-09 14:51:22,561 - httpcore.connection - DEBUG - connect_tcp.started host='api.telegram.org' port=443 local_address=None timeout=5.0 socket_options=None
2024-06-09 14:51:22,562 - httpcore.connection - DEBUG - connect_tcp.failed exception=ConnectError(gaierror(-3, 'Temporary failure in name resolution'))
```
